### PR TITLE
Feature: Add Fig spec generation command

### DIFF
--- a/cli/cmd/encore/generateFigSpec.go
+++ b/cli/cmd/encore/generateFigSpec.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	cobracompletefig "github.com/withfig/autocomplete-tools/integrations/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(cobracompletefig.CreateCompletionSpecCommand())
+}

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
+	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1445,6 +1445,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
+github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1 h1:+dBg5k7nuTE38VVdoroRsT0Z88fmvdYrI2EjzJst35I=
+github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1/go.mod h1:nmuySobZb4kFgFy6BptpXp/BBw+xFSyvVPP6auoJB4k=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=


### PR DESCRIPTION
## Added 
- [`b37395d`](https://github.com/BogDAAAMN/encore/commit/b37395ded4b3cfc4ad343fe3ce6bd08e9d8fd1c1): go get `github.com/withfig/autocomplete-tools/integrations/cobra`
- [`e4fa29c`](https://github.com/BogDAAAMN/encore/commit/e4fa29c1a3e22eee6dea1ed15da8f62751d51a50): Add generate-fig-spec hidden command